### PR TITLE
Feat/service request contract improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# Escrow
+- Customer pays to escrow, inserting order detail data
+- When Lab fulfills order at substrate blockchain, backend receives order fulfilled event
+  - On order fulfilled, backend triggers Escrow.fulfillOrder:
+    - Transfer QC paymen to *Lab*
+    - Transfer Testing payment to *Lab* 
+- When Lab reject dna sample, backend receives dnaSample rejected event:
+  - On dnaSample rejected backend triggers Escrow.refundOrder:
+    - Transfer QC payment to *Lab*
+    - Transfer Testing payment to *Customer*
+
 # Request Test Staking
 Customer sends a request for a test to a lab.
 If there is no lab in their country,city then the request is also valid. The request will be used as a gauge of interest for the particular type of test in that city.
@@ -49,3 +60,4 @@ To make this request, a customer would have to stake a certain amount of DAI
 ## Deployed Contract Address
 Refer to ./deployed-addresses for the last deployed contract addresses.
 Currently deployed in private network for development.
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Escrow
+## How it Works
 - Customer pays to escrow, inserting order detail data
 - When Lab fulfills order at substrate blockchain, backend receives order fulfilled event
   - On order fulfilled, backend triggers Escrow.fulfillOrder:
@@ -9,24 +10,41 @@
     - Transfer QC payment to *Lab*
     - Transfer Testing payment to *Customer*
 
+## TODO:
+- [ ] allOrders should only hold order ids
+- [ ] ordersBySellerSubstrateAddress should only hold order ids
+- [ ] ordersByCustomerSubstrateAddress should only hold order ids
+- [ ] remove orderByHash mapping because orderId is already a hash
+
 # Request Test Staking
-Customer sends a request for a test to a lab.
-If there is no lab in their country,city then the request is also valid. The request will be used as a gauge of interest for the particular type of test in that city.
-Labs/future labs can receive the staking amount by providing the service requested.
-Whether or not the service fulfills the request, will need to be determined by DAOGenics.   
-To make this request, a customer would have to stake a certain amount of DAI
+## Making a request
+Customer sends a request for a test in a location which there is no labs.
+The request also requires the user to stake an amount of DAI as an incentive for labs to fulfill the request.
+
+## Claiming a request
+Labs/Future labs can receive the staking amount reward by claiming the request, and fulfilling the request by providing the service.
+DAOGenics will need to validate the service before lab can claim the request. This is done by calling a transaction in the smart contract, updating a mapping of valid lab services.
 
 ## Data Structure
 ### Service Request
 ```solidity
   struct Request {
-    string requesterSubstrateAddress;
-    string labSubstrateAddress; // optional
-    string country; // optional, mandatory if labSubstrateAddress is empty
-    string city; // optional, mandatory if labSubstrateAddress is empty
-    string service;
+    address requesterAddress;
+    address labAddress; // Added when lab claimed the request
+    string country;
+    string city;
+    string serviceCategory;
     uint stakingAmount;
+    RequestStatus status; // { OPEN, CLAIMED }
+    bytes32 hash;
+    bool exists;
   }
+```
+### Valid Lab Services
+```solidity
+      // labID       serviceCategory  serviceID
+  mapping(bytes32 => mapping(string => bytes32)) public labValidServices;
+
 ```
 
 ## How it works

--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -27,9 +27,11 @@ contract Escrow {
   }
 
   IERC20 public _token;
+  address public _escrowAdmin;
 
-  constructor(address ERC20Address) {
+  constructor(address ERC20Address, address escrowAdmin) {
     _token = IERC20(ERC20Address);
+    _escrowAdmin = escrowAdmin;
   }
 
   // total orders count
@@ -73,6 +75,11 @@ contract Escrow {
   }
 
   function refundOrder(bytes32 hash) external {
+    // TODO:
+    // QC amount transferred to seller should be reduced by gas price
+    // Testing price amount transferred to buyer should be reduced by gas price
+
+    require(msg.sender == _escrowAdmin, "Only Escrow Admin allowed to do refund");
     // Transfer QC price to lab
     require(_token.transfer(orderByHash[hash].sellerAddress, orderByHash[hash].qcPrice), "QC Payment to lab failed");
     // Refund customer
@@ -85,6 +92,10 @@ contract Escrow {
   }
 
   function fulfillOrder(bytes32 hash) external {
+    // TODO:
+    // Total price amount transferred to seller should be reduced by gas price
+
+    require(msg.sender == _escrowAdmin, "Only Escrow Admin allowed to do order fulfillment");
     // Transfer testing and QC price to lab
     uint totalPrice = orderByHash[hash].testingPrice + orderByHash[hash].qcPrice;
     require(_token.transfer(orderByHash[hash].sellerAddress, totalPrice), "Payment to lab failed");
@@ -95,7 +106,7 @@ contract Escrow {
     emit OrderFulfilled(orderByHash[hash]);
   }
 
-  function orderPaid(
+  function payOrder(
     string memory orderId,
     string memory serviceId,
     string memory customerSubstrateAddress,

--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -1,0 +1,185 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "hardhat/console.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract Escrow {
+  enum OrderStatus { PAID, FULFILLED, REFUNDED }
+
+  struct Price{
+    string component;
+    uint value;
+  }
+
+  struct Order {
+    string orderId;
+    string serviceId;
+    string customerSubstrateAddress;
+    string sellerSubstrateAddress;
+    string dnaSampleTrackingId;
+    uint testingPrice;
+    uint qcPrice;
+    address customerAddress;
+    address sellerAddress;
+    OrderStatus status;
+    bytes32 hash;
+  }
+
+  IERC20 public _token;
+
+  constructor(address ERC20Address) {
+    _token = IERC20(ERC20Address);
+  }
+
+  // total orders count
+  uint orderCount;
+  // All of the orders
+  Order[] allOrders;
+
+  // Hash -> Order
+  mapping(bytes32 => Order) public orderByHash;
+  // OrderId -> Order
+  mapping(bytes32 => Order) public orderByOrderId;
+  // Customer Substrate Address -> Order[]
+  mapping(bytes32 => Order[]) public ordersByCustomerSubstrateAddress;
+  // Seller Substrate Address -> Order[]
+  mapping(bytes32 => Order[]) public ordersBySellerSubstrateAddress;
+
+  event OrderPaid(Order order);
+
+  event OrderRefunded(Order order);
+
+  event OrderFulfilled(Order order);
+
+  function hashOrder(
+    string memory orderId,
+    string memory serviceId,
+    string memory customerSubstrateAddress,
+    string memory sellerSubstrateAddress,
+    string memory dnaSampleTrackingId,
+    uint testingPrice,
+    uint qcPrice
+  ) internal pure returns (bytes32 hash){
+    return keccak256(abi.encodePacked(
+        orderId,
+        serviceId,
+        customerSubstrateAddress,
+        sellerSubstrateAddress,
+        dnaSampleTrackingId,
+        testingPrice,
+        qcPrice
+    ));
+  }
+
+  function refundOrder(bytes32 hash) external {
+    // Transfer QC price to lab
+    require(_token.transferFrom(address(this), orderByHash[hash].sellerAddress, orderByHash[hash].qcPrice), "QC Payment to lab failed");
+    // Refund customer
+    require(_token.transferFrom(address(this), orderByHash[hash].customerAddress, orderByHash[hash].testingPrice), "Refund to customer failed");
+    
+    // If all is done, status is refunded
+    orderByHash[hash].status = OrderStatus.REFUNDED;
+
+    emit OrderRefunded(orderByHash[hash]);
+  }
+
+  function fulfillOrder(bytes32 hash) external {
+    // Transfer testing and QC price to lab
+    uint totalPrice = orderByHash[hash].testingPrice + orderByHash[hash].qcPrice;
+    require(_token.transferFrom(address(this), orderByHash[hash].sellerAddress, totalPrice), "Payment to lab failed");
+    
+    // If all is done, status is fulfilled
+    orderByHash[hash].status = OrderStatus.FULFILLED;
+
+    emit OrderFulfilled(orderByHash[hash]);
+  }
+
+  function orderPaid(
+    string memory orderId,
+    string memory serviceId,
+    string memory customerSubstrateAddress,
+    string memory sellerSubstrateAddress,
+    address customerAddress,
+    address sellerAddress,
+    string memory dnaSampleTrackingId,
+    uint testingPrice,
+    uint qcPrice
+  ) external {
+
+    require(testingPrice != 0, "Testing Price cannot be 0");
+    require(qcPrice != 0, "QC Price cannot be 0");
+
+    // Transfer erc20 token from sender to this contract
+    uint totalPrice = testingPrice + qcPrice;
+    require(_token.transferFrom(msg.sender, address(this), totalPrice), "Transfer to escrow failed");
+    
+    bytes32 orderHash = hashOrder(
+        orderId,
+        serviceId,
+        customerSubstrateAddress,
+        sellerSubstrateAddress,
+        dnaSampleTrackingId,
+        testingPrice,
+        qcPrice
+    );
+    
+    Order memory order = Order(
+      orderId,
+      serviceId,
+      customerSubstrateAddress,
+      sellerSubstrateAddress,
+      dnaSampleTrackingId,
+      testingPrice,
+      qcPrice,
+      customerAddress,
+      sellerAddress,
+      OrderStatus.PAID,
+      orderHash
+    );
+
+    allOrders.push(order);
+
+    orderByHash[orderHash] = order;
+    
+    bytes32 orderIdKey = keccak256(abi.encodePacked(orderId));
+    orderByOrderId[orderIdKey] = order;
+
+    bytes32 customerSubstrateAddressKey = keccak256(abi.encodePacked(customerSubstrateAddress));
+    ordersByCustomerSubstrateAddress[customerSubstrateAddressKey].push(order);
+
+    bytes32 sellerSubstrateAddressKey = keccak256(abi.encodePacked(sellerSubstrateAddress));
+    ordersBySellerSubstrateAddress[sellerSubstrateAddressKey].push(order);
+
+    orderCount++;
+
+    emit OrderPaid(order);
+  }
+
+  function getOrderCount() external view returns (uint) {
+    return orderCount;
+  }
+
+  function getAllOrders() external view returns (Order[] memory) {
+    return allOrders;
+  }
+
+  function getOrderByHash(bytes32 hash) external view returns (Order memory) {
+    return orderByHash[hash];
+  }
+
+  function getOrderByOrderId(string memory orderId) external view returns (Order memory) {
+    bytes32 orderIdKey = keccak256(abi.encodePacked(orderId));
+    return orderByOrderId[orderIdKey];
+  }
+
+  function getOrdersByCustomerSubstrateAddress(string memory customerSubstrateAddress) external view returns (Order[] memory) {
+    bytes32 customerSubstrateAddressKey = keccak256(abi.encodePacked(customerSubstrateAddress));
+    return ordersByCustomerSubstrateAddress[customerSubstrateAddressKey];
+  }
+
+  function getOrdersBySellerSubstrateAddress(string memory sellerSubstrateAddress) external view returns (Order[] memory) {
+    bytes32 sellerSubstrateAddressKey = keccak256(abi.encodePacked(sellerSubstrateAddress));
+    return ordersBySellerSubstrateAddress[sellerSubstrateAddressKey];
+  }
+}

--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -74,9 +74,9 @@ contract Escrow {
 
   function refundOrder(bytes32 hash) external {
     // Transfer QC price to lab
-    require(_token.transferFrom(address(this), orderByHash[hash].sellerAddress, orderByHash[hash].qcPrice), "QC Payment to lab failed");
+    require(_token.transfer(orderByHash[hash].sellerAddress, orderByHash[hash].qcPrice), "QC Payment to lab failed");
     // Refund customer
-    require(_token.transferFrom(address(this), orderByHash[hash].customerAddress, orderByHash[hash].testingPrice), "Refund to customer failed");
+    require(_token.transfer(orderByHash[hash].customerAddress, orderByHash[hash].testingPrice), "Refund to customer failed");
     
     // If all is done, status is refunded
     orderByHash[hash].status = OrderStatus.REFUNDED;
@@ -87,7 +87,7 @@ contract Escrow {
   function fulfillOrder(bytes32 hash) external {
     // Transfer testing and QC price to lab
     uint totalPrice = orderByHash[hash].testingPrice + orderByHash[hash].qcPrice;
-    require(_token.transferFrom(address(this), orderByHash[hash].sellerAddress, totalPrice), "Payment to lab failed");
+    require(_token.transfer(orderByHash[hash].sellerAddress, totalPrice), "Payment to lab failed");
     
     // If all is done, status is fulfilled
     orderByHash[hash].status = OrderStatus.FULFILLED;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13756,9 +13756,9 @@
       }
     },
     "web3-utils": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.0.tgz",
-      "integrity": "sha512-hNyw7Oxi6TM3ivXmv4hK5Cvyi9ML3UoKtcCYvLF9woPWh5v2dwCCVO1U3Iq5HHK7Dqq28t1d4CxWHqUfOfAkgg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+      "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
       "dev": true,
       "requires": {
         "bn.js": "^4.11.9",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "chai": "^4.3.4",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.4.3",
-    "hardhat": "^2.5.0"
+    "hardhat": "^2.5.0",
+    "web3-utils": "^1.5.2"
   },
   "dependencies": {
     "dotenv": "^10.0.0"

--- a/test/escrow-test.js
+++ b/test/escrow-test.js
@@ -231,7 +231,7 @@ describe('Escrow', function () {
     await fulfillTx.wait();
 
     order = await contract.getOrderByHash(order.hash);
-    expect(order.status).to.equal(2);
+    expect(order.status).to.equal(1);
   })
 
   it("Lab can refund a order (Updates order status to refunded)", async function () {

--- a/test/escrow-test.js
+++ b/test/escrow-test.js
@@ -5,11 +5,11 @@ require('dotenv').config();
 describe('Escrow', function () {
   let contract;
   // Request Parameters
-  const orderId = "4KTmcB6iDV9HElHq2s1Q";
-  const serviceId = "xLNpoyWsY63Z8SYQeBHf";
-  const customerSubstrateAddress = "700fJuhXgfwi9WjBovRy";
-  const sellerSubstrateAddress = "Lg9Z3Ncbn5VNnxuJEVxX";
-  const dnaSampleTrackingId = "3CQguUxa2pOodID3Ni62";
+  const orderId = "0xed19fb816f3d4a3d4f46e0445bd68a666647bc5fd77c60c937b170a398c49e51";
+  const serviceId = "0xe88f0531fea1654b6a24197ec1025fd7217bb8b19d619bd488105504ec244df8";
+  const customerSubstrateAddress = "5EBs6czjmUy31iawezsude3vudFVfi9gMv6kAHjNeBzzGgvH";
+  const sellerSubstrateAddress = "5ESGhRuAhECXu96Pz9L8pwEEd1AeVhStXX67TWE1zHRuvJNU";
+  const dnaSampleTrackingId = "Y9JCOABLP16GKHQ14RY9J";
   const testingPrice = 10
   const qcPrice = 3
 

--- a/test/escrow-test.js
+++ b/test/escrow-test.js
@@ -1,0 +1,252 @@
+const { expect } = require('chai')
+require("@nomiclabs/hardhat-waffle");
+
+describe('Escrow', function () {
+  let contract;
+  // Request Parameters
+  const orderId = "4KTmcB6iDV9HElHq2s1Q";
+  const serviceId = "xLNpoyWsY63Z8SYQeBHf";
+  const customerSubstrateAddress = "700fJuhXgfwi9WjBovRy";
+  const sellerSubstrateAddress = "Lg9Z3Ncbn5VNnxuJEVxX";
+  const dnaSampleTrackingId = "3CQguUxa2pOodID3Ni62";
+  const testingPrice = 10
+  const qcPrice = 3
+
+  let customerAddress;
+  let sellerAddress;
+  let iDontHaveTokens;
+
+  before(async function () {
+    /**
+     * Deploy ERC20 token
+     * */
+    const ERC20Contract = await ethers.getContractFactory("DebioToken");
+    const erc20 = await ERC20Contract.deploy();
+    await erc20.deployed()
+
+    /**
+     * Get test accounts
+     * */
+    const accounts = await hre.ethers.getSigners();
+    // accounts[0] is the deployer
+    customerAddress = accounts[1];
+    sellerAddress = accounts[2];
+    iDontHaveTokens = accounts[3];
+
+    /**
+     * Transfer some ERC20s to customerAddress
+     * */
+    const transferTx = await erc20.transfer(customerAddress.address, "90000000000000000000");
+    await transferTx.wait();
+
+    /**
+     * Transfer some ERC20s to sellerAddress
+     * */
+    const transferTx2 = await erc20.transfer(sellerAddress.address, "90000000000000000000");
+    await transferTx2.wait();
+
+    /**
+     * Deploy Escrow Contract
+     * */
+    const EscrowtContract = await ethers.getContractFactory("Escrow");
+    contract = await EscrowtContract.deploy(erc20.address);
+    await contract.deployed();
+
+    /** 
+     * Seed request data
+     * */
+    const erc20WithSigner = erc20.connect(customerAddress);
+    const contractWithSigner = contract.connect(customerAddress);
+
+    const approveTx = await erc20WithSigner.approve(contract.address, "90000000000000000000");
+    await approveTx.wait();
+
+    const orderPaidTx = await contractWithSigner.orderPaid(
+        orderId,
+        serviceId,
+        customerSubstrateAddress,
+        sellerSubstrateAddress,
+        customerAddress.address,
+        sellerAddress.address,
+        dnaSampleTrackingId,
+        testingPrice,
+        qcPrice
+    )
+    // wait until transaction is mined
+    await orderPaidTx.wait();
+  });
+
+  it("Should fail if sender does not have enough ERC20 token balance", async function () {
+    let errMsg;
+    try {
+      const contractWithSigner = contract.connect(iDontHaveTokens)
+      const tx = await contractWithSigner.orderPaid(
+        orderId,
+        serviceId,
+        customerSubstrateAddress,
+        sellerSubstrateAddress,
+        customerAddress.address,
+        sellerAddress.address,
+        dnaSampleTrackingId,
+        testingPrice,
+        qcPrice
+      )
+    } catch (err) {
+      errMsg = err.message
+    }
+    expect(errMsg).to.equal("VM Exception while processing transaction: reverted with reason string 'ERC20: transfer amount exceeds balance'");
+  })
+
+  it("Should return order by order Id", async function () {
+    const req = await contract.getOrderByOrderId(orderId);
+    
+    expect(req.orderId).to.equal(orderId);
+    expect(req.serviceId).to.equal(serviceId);
+    expect(req.customerSubstrateAddress).to.equal(customerSubstrateAddress);
+    expect(req.sellerSubstrateAddress).to.equal(sellerSubstrateAddress);
+    expect(req.customerAddress).to.equal(customerAddress.address);
+    expect(req.sellerAddress).to.equal(sellerAddress.address);
+    expect(req.dnaSampleTrackingId).to.equal(dnaSampleTrackingId);
+    expect(req.testingPrice.toString()).to.equal(testingPrice.toString());
+    expect(req.qcPrice.toString()).to.equal(qcPrice.toString());
+  })
+
+  it("Should return orders by customer substrate address", async function () {
+    const orders = await contract.getOrdersByCustomerSubstrateAddress(customerSubstrateAddress);    
+    
+    for (let req of orders) {
+        expect(req.orderId).to.equal(orderId);
+        expect(req.serviceId).to.equal(serviceId);
+        expect(req.customerSubstrateAddress).to.equal(customerSubstrateAddress);
+        expect(req.sellerSubstrateAddress).to.equal(sellerSubstrateAddress);
+        expect(req.customerAddress).to.equal(customerAddress.address);
+        expect(req.sellerAddress).to.equal(sellerAddress.address);
+        expect(req.dnaSampleTrackingId).to.equal(dnaSampleTrackingId);
+        expect(req.testingPrice.toString()).to.equal(testingPrice.toString());
+        expect(req.qcPrice.toString()).to.equal(qcPrice.toString());
+    }
+  })
+
+  it("Should return orders by seller substrate address", async function () {
+    const orders = await contract.getOrdersBySellerSubstrateAddress(sellerSubstrateAddress);    
+    for (let req of orders) {
+        expect(req.orderId).to.equal(orderId);
+        expect(req.serviceId).to.equal(serviceId);
+        expect(req.customerSubstrateAddress).to.equal(customerSubstrateAddress);
+        expect(req.sellerSubstrateAddress).to.equal(sellerSubstrateAddress);
+        expect(req.customerAddress).to.equal(customerAddress.address);
+        expect(req.sellerAddress).to.equal(sellerAddress.address);
+        expect(req.dnaSampleTrackingId).to.equal(dnaSampleTrackingId);
+        expect(req.testingPrice.toString()).to.equal(testingPrice.toString());
+        expect(req.qcPrice.toString()).to.equal(qcPrice.toString());
+    }
+  })
+
+  it("Should emit OrderPaid event, when order is paid", async function () {
+    // Request Parameters
+    const orderId = "700fJuhXgfwi9WjBovRy";
+    const serviceId = "Lg9Z3Ncbn5VNnxuJEVxX";
+    const customerSubstrateAddress = "4KTmcB6iDV9HElHq2s1Q";
+    const sellerSubstrateAddress = "3CQguUxa2pOodID3Ni62";
+    const dnaSampleTrackingId = "xLNpoyWsY63Z8SYQeBHf";
+    const testingPrice = 10
+    const qcPrice = 3
+
+    const contractWithSigner = contract.connect(customerAddress);
+    const orderAddedTx = await contractWithSigner.orderPaid(
+        orderId,
+        serviceId,
+        customerSubstrateAddress,
+        sellerSubstrateAddress,
+        customerAddress.address,
+        sellerAddress.address,
+        dnaSampleTrackingId,
+        testingPrice,
+        qcPrice
+    )
+    // wait until transaction is mined
+    const receipt = await orderAddedTx.wait();
+    // Get event from receipt
+    const events = receipt.events.filter((x) => x.event == "OrderPaid");
+    expect(events.length > 0).to.equal(true);
+    // Get the request data from the event
+    const req = events[0].args[0]
+
+    expect(req.orderId).to.equal(orderId);
+    expect(req.serviceId).to.equal(serviceId);
+    expect(req.customerSubstrateAddress).to.equal(customerSubstrateAddress);
+    expect(req.sellerSubstrateAddress).to.equal(sellerSubstrateAddress);
+    expect(req.customerAddress).to.equal(customerAddress.address);
+    expect(req.sellerAddress).to.equal(sellerAddress.address);
+    expect(req.dnaSampleTrackingId).to.equal(dnaSampleTrackingId);
+    expect(req.testingPrice.toString()).to.equal(testingPrice.toString());
+    expect(req.qcPrice.toString()).to.equal(qcPrice.toString());
+
+    const orderCount = await contract.getOrderCount();
+    expect(orderCount).to.equal(2);
+  })
+
+  it("Should return all orders", async function () {
+    const orders = await contract.getAllOrders();
+    expect(orders.length).to.equal(2);
+    const order = orders[0]
+    
+    expect(order.orderId).to.equal(orderId);
+    expect(order.serviceId).to.equal(serviceId);
+    expect(order.customerSubstrateAddress).to.equal(customerSubstrateAddress);
+    expect(order.sellerSubstrateAddress).to.equal(sellerSubstrateAddress);
+    expect(order.customerAddress).to.equal(customerAddress.address);
+    expect(order.sellerAddress).to.equal(sellerAddress.address);
+    expect(order.dnaSampleTrackingId).to.equal(dnaSampleTrackingId);
+    expect(order.testingPrice.toString()).to.equal(testingPrice.toString());
+    expect(order.qcPrice.toString()).to.equal(qcPrice.toString());
+  })
+
+  it("Should return order by order hash", async function () {
+    const orders = await contract.getAllOrders();
+    const order = orders[0]
+    const orderByHash = await contract.getOrderByHash(order.hash)
+
+    expect(order.orderId).to.equal(orderByHash.orderId);
+    expect(order.serviceId).to.equal(orderByHash.serviceId);
+    expect(order.customerSubstrateAddress).to.equal(orderByHash.customerSubstrateAddress);
+    expect(order.sellerSubstrateAddress).to.equal(orderByHash.sellerSubstrateAddress);
+    expect(order.customerAddress).to.equal(orderByHash.customerAddress);
+    expect(order.sellerAddress).to.equal(orderByHash.sellerAddress);
+    expect(order.dnaSampleTrackingId).to.equal(orderByHash.dnaSampleTrackingId);
+    expect(order.testingPrice.toString()).to.equal(orderByHash.testingPrice.toString());
+    expect(order.qcPrice.toString()).to.equal(orderByHash.qcPrice.toString());
+  })
+
+  it("Lab can fulfill a order (Updates order status to fulfilled)", async function () {
+    /**
+     * enum RequestStatus { PAID, FULFILLED, REFUNDED }
+     */
+    const orders = await contract.getAllOrders();
+    let order = orders[0];
+    expect(order.status).to.equal(0);
+
+    const contractWithSigner = contract.connect(sellerAddress);
+    const fulfillTx = await contractWithSigner.fulfillOrder(order.hash);
+    await fulfillTx.wait();
+
+    order = await contract.getOrderByHash(order.hash);
+    expect(order.status).to.equal(2);
+  })
+
+  it("Lab can refund a order (Updates order status to refunded)", async function () {
+    /**
+     * enum RequestStatus { PAID, FULFILLED, REFUNDED }
+     */
+    const orders = await contract.getAllOrders();
+    let order = orders[0];
+    expect(order.status).to.equal(0);
+
+    const contractWithSigner = contract.connect(sellerAddress);
+    const fulfillTx = await contractWithSigner.refundOrder(order.hash);
+    await fulfillTx.wait();
+
+    order = await contract.getOrderByHash(order.hash);
+    expect(order.status).to.equal(2);
+  })
+})


### PR DESCRIPTION
 - Remove storing substrateAddress
  - mappings of request list now only stores hashes of request
  - DAOGenics can add valid lab services to contract
  - Lab can claim request if their service for corresponding service
    category is valid