### PR TITLE
feat: Escrow Accounts Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,7 @@
   - On dnaSample rejected backend triggers Escrow.refundOrder:
     - Transfer QC payment to *Lab*
     - Transfer Testing payment to *Customer*
-## TODO:
-- [ ] allOrders should only hold order ids
-- [ ] ordersBySellerSubstrateAddress should only hold order ids
-- [ ] ordersByCustomerSubstrateAddress should only hold order ids
-- [ ] remove orderByHash mapping because orderId is already a hash
+
 
 # Request Test Staking
 ## Making a request

--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -13,8 +13,8 @@ contract Escrow {
   }
 
   struct Order {
-    string orderId;
-    string serviceId;
+    bytes32 orderId;
+    bytes32 serviceId;
     string customerSubstrateAddress;
     string sellerSubstrateAddress;
     string dnaSampleTrackingId;
@@ -23,7 +23,6 @@ contract Escrow {
     address customerAddress;
     address sellerAddress;
     OrderStatus status;
-    bytes32 hash;
   }
 
   IERC20 public _token;
@@ -37,16 +36,14 @@ contract Escrow {
   // total orders count
   uint orderCount;
   // All of the orders
-  Order[] allOrders;
+  bytes32[] allOrders;
 
-  // Hash -> Order
-  mapping(bytes32 => Order) public orderByHash;
   // OrderId -> Order
   mapping(bytes32 => Order) public orderByOrderId;
   // Customer Substrate Address -> Order[]
-  mapping(bytes32 => Order[]) public ordersByCustomerSubstrateAddress;
+  mapping(bytes32 => bytes32[]) public ordersByCustomerSubstrateAddress;
   // Seller Substrate Address -> Order[]
-  mapping(bytes32 => Order[]) public ordersBySellerSubstrateAddress;
+  mapping(bytes32 => bytes32[]) public ordersBySellerSubstrateAddress;
 
   event OrderPaid(Order order);
 
@@ -54,61 +51,41 @@ contract Escrow {
 
   event OrderFulfilled(Order order);
 
-  function hashOrder(
-    string memory orderId,
-    string memory serviceId,
-    string memory customerSubstrateAddress,
-    string memory sellerSubstrateAddress,
-    string memory dnaSampleTrackingId,
-    uint testingPrice,
-    uint qcPrice
-  ) internal pure returns (bytes32 hash){
-    return keccak256(abi.encodePacked(
-        orderId,
-        serviceId,
-        customerSubstrateAddress,
-        sellerSubstrateAddress,
-        dnaSampleTrackingId,
-        testingPrice,
-        qcPrice
-    ));
-  }
-
-  function refundOrder(bytes32 hash) external {
+  function refundOrder(bytes32 orderId) external {
     // TODO:
     // QC amount transferred to seller should be reduced by gas price
     // Testing price amount transferred to buyer should be reduced by gas price
 
     require(msg.sender == _escrowAdmin, "Only Escrow Admin allowed to do refund");
     // Transfer QC price to lab
-    require(_token.transfer(orderByHash[hash].sellerAddress, orderByHash[hash].qcPrice), "QC Payment to lab failed");
+    require(_token.transfer(orderByOrderId[orderId].sellerAddress, orderByOrderId[orderId].qcPrice), "QC Payment to lab failed");
     // Refund customer
-    require(_token.transfer(orderByHash[hash].customerAddress, orderByHash[hash].testingPrice), "Refund to customer failed");
+    require(_token.transfer(orderByOrderId[orderId].customerAddress, orderByOrderId[orderId].testingPrice), "Refund to customer failed");
     
     // If all is done, status is refunded
-    orderByHash[hash].status = OrderStatus.REFUNDED;
+    orderByOrderId[orderId].status = OrderStatus.REFUNDED;
 
-    emit OrderRefunded(orderByHash[hash]);
+    emit OrderRefunded(orderByOrderId[orderId]);
   }
 
-  function fulfillOrder(bytes32 hash) external {
+  function fulfillOrder(bytes32 orderId) external {
     // TODO:
     // Total price amount transferred to seller should be reduced by gas price
 
     require(msg.sender == _escrowAdmin, "Only Escrow Admin allowed to do order fulfillment");
     // Transfer testing and QC price to lab
-    uint totalPrice = orderByHash[hash].testingPrice + orderByHash[hash].qcPrice;
-    require(_token.transfer(orderByHash[hash].sellerAddress, totalPrice), "Payment to lab failed");
+    uint totalPrice = orderByOrderId[orderId].testingPrice + orderByOrderId[orderId].qcPrice;
+    require(_token.transfer(orderByOrderId[orderId].sellerAddress, totalPrice), "Payment to lab failed");
     
     // If all is done, status is fulfilled
-    orderByHash[hash].status = OrderStatus.FULFILLED;
+    orderByOrderId[orderId].status = OrderStatus.FULFILLED;
 
-    emit OrderFulfilled(orderByHash[hash]);
+    emit OrderFulfilled(orderByOrderId[orderId]);
   }
 
   function payOrder(
-    string memory orderId,
-    string memory serviceId,
+    bytes32 orderId,
+    bytes32 serviceId,
     string memory customerSubstrateAddress,
     string memory sellerSubstrateAddress,
     address customerAddress,
@@ -125,16 +102,6 @@ contract Escrow {
     uint totalPrice = testingPrice + qcPrice;
     require(_token.transferFrom(msg.sender, address(this), totalPrice), "Transfer to escrow failed");
     
-    bytes32 orderHash = hashOrder(
-        orderId,
-        serviceId,
-        customerSubstrateAddress,
-        sellerSubstrateAddress,
-        dnaSampleTrackingId,
-        testingPrice,
-        qcPrice
-    );
-    
     Order memory order = Order(
       orderId,
       serviceId,
@@ -145,22 +112,18 @@ contract Escrow {
       qcPrice,
       customerAddress,
       sellerAddress,
-      OrderStatus.PAID,
-      orderHash
+      OrderStatus.PAID
     );
 
-    allOrders.push(order);
+    allOrders.push(orderId);
 
-    orderByHash[orderHash] = order;
-    
-    bytes32 orderIdKey = keccak256(abi.encodePacked(orderId));
-    orderByOrderId[orderIdKey] = order;
+    orderByOrderId[orderId] = order;
 
     bytes32 customerSubstrateAddressKey = keccak256(abi.encodePacked(customerSubstrateAddress));
-    ordersByCustomerSubstrateAddress[customerSubstrateAddressKey].push(order);
+    ordersByCustomerSubstrateAddress[customerSubstrateAddressKey].push(orderId);
 
     bytes32 sellerSubstrateAddressKey = keccak256(abi.encodePacked(sellerSubstrateAddress));
-    ordersBySellerSubstrateAddress[sellerSubstrateAddressKey].push(order);
+    ordersBySellerSubstrateAddress[sellerSubstrateAddressKey].push(orderId);
 
     orderCount++;
 
@@ -171,25 +134,20 @@ contract Escrow {
     return orderCount;
   }
 
-  function getAllOrders() external view returns (Order[] memory) {
+  function getAllOrders() external view returns (bytes32[] memory) {
     return allOrders;
   }
 
-  function getOrderByHash(bytes32 hash) external view returns (Order memory) {
-    return orderByHash[hash];
+  function getOrderByOrderId(bytes32 orderId) external view returns (Order memory) {
+    return orderByOrderId[orderId];
   }
 
-  function getOrderByOrderId(string memory orderId) external view returns (Order memory) {
-    bytes32 orderIdKey = keccak256(abi.encodePacked(orderId));
-    return orderByOrderId[orderIdKey];
-  }
-
-  function getOrdersByCustomerSubstrateAddress(string memory customerSubstrateAddress) external view returns (Order[] memory) {
+  function getOrdersByCustomerSubstrateAddress(string memory customerSubstrateAddress) external view returns (bytes32[] memory) {
     bytes32 customerSubstrateAddressKey = keccak256(abi.encodePacked(customerSubstrateAddress));
     return ordersByCustomerSubstrateAddress[customerSubstrateAddressKey];
   }
 
-  function getOrdersBySellerSubstrateAddress(string memory sellerSubstrateAddress) external view returns (Order[] memory) {
+  function getOrdersBySellerSubstrateAddress(string memory sellerSubstrateAddress) external view returns (bytes32[] memory) {
     bytes32 sellerSubstrateAddressKey = keccak256(abi.encodePacked(sellerSubstrateAddress));
     return ordersBySellerSubstrateAddress[sellerSubstrateAddressKey];
   }


### PR DESCRIPTION
- Test QC price and Testing price transffered correctly to the
  associated accounts
- Remove hash from Order struct. Because Order.orderId is already a hash